### PR TITLE
feat(teil_lints): disabling the sort_constructors_first rule

### DIFF
--- a/packages/teil_lints/lib/presets/analysis_options.yaml
+++ b/packages/teil_lints/lib/presets/analysis_options.yaml
@@ -20,3 +20,4 @@ dart_code_metrics:
 linter:
   rules:
     one_member_abstracts: false
+    sort_constructors_first: false


### PR DESCRIPTION
## Related Issues

The sort_constructors_first rule makes the code read unconventionally, making the development experience difficult.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I followed the [Conventional Commits] naming convention.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`)
- [x] All existing and new tests are passing.
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[teil_lints]`

---

## Description

Disabling the sort_constructors_first rule. https://dart-lang.github.io/linter/lints/sort_constructors_first.html